### PR TITLE
Fixing \n character issue on memory object

### DIFF
--- a/index.js
+++ b/index.js
@@ -632,7 +632,7 @@ class Hydra extends EventEmitter {
     let map = {};
     let memory = util.inspect(process.memoryUsage());
 
-    memory = memory.replace(/[\ \{\}]/g, '');
+    memory = memory.replace(/[\ \{\}.|\n]/g, '');
     lines = memory.split(',');
 
     Array.from(lines, (line) => {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,6 @@ class Hydra extends EventEmitter {
 
     this.mcMessageChannelClient;
     this.mcDirectMessageChannelClient;
-    this.messageChannelPool = {};
     this.config = null;
     this.serviceName = '';
     this.serviceDescription = '';
@@ -59,6 +58,9 @@ class Hydra extends EventEmitter {
     this._updateHealthCheck = this._updateHealthCheck.bind(this);
     this.registeredRoutes = [];
     this.registeredPlugins = [];
+
+    this.publisherChannels = {};
+    this.subscriberChannels = {};
   }
 
   /**
@@ -184,9 +186,6 @@ class Hydra extends EventEmitter {
       this.mcDirectMessageChannelClient.unsubscribe();
       this.mcDirectMessageChannelClient.quit();
     }
-    Object.keys(this.messageChannelPool).forEach((keyname) => {
-      this.messageChannelPool[keyname].quit();
-    });
     if (this.redisdb) {
       this.redisdb.del(`${redisPreKey}:${this.serviceName}:${this.instanceID}:presence`, () => {
         this.redisdb.quit();
@@ -238,7 +237,9 @@ class Hydra extends EventEmitter {
           password: parsedUrl.password
         };
       }
-      let redisConfig = Object.assign({db: HYDRA_REDIS_DB}, url, config.redis, {
+      let redisConfig = Object.assign({
+        db: HYDRA_REDIS_DB
+      }, url, config.redis, {
         retry_strategy: this._redisRetryStrategy(config.redis.retry_strategy, reject)
       });
       if (redisConfig.host) {
@@ -398,45 +399,45 @@ class Hydra extends EventEmitter {
         reject(new Error('No Redis connection'));
         return;
       }
-      let routesKey = `${redisPreKey}:${this.serviceName}:service:routes`;
-      let trans = this.redisdb.multi();
-      routes.forEach((route) => {
-        trans.sadd(routesKey, route);
-      });
-      trans.exec((err, result) => {
-        if (err) {
-          reject(err);
-        } else {
-          return this._getRoutes()
-            .then((routeList) => {
-              if (routeList.length) {
-                this.registeredRoutes = [];
-                routeList.forEach((route) => {
-                  this.registeredRoutes.push(new Route(route));
-                });
-                if (this.serviceName !== 'hydra-router') {
-                  // let routers know that a new service route was registered
-                  resolve();
-                  return this._sendBroadcastMessage(UMFMessage.createMessage({
-                    to: 'hydra-router:/refresh',
-                    from: `${this.serviceName}:/`,
-                    body: {
-                      action: 'refresh',
-                      serviceName: this.serviceName
-                    }
-                  }));
+      this._flushRoutes().then(() => {
+        let routesKey = `${redisPreKey}:${this.serviceName}:service:routes`;
+        let trans = this.redisdb.multi();
+        routes.forEach((route) => {
+          trans.sadd(routesKey, route);
+        });
+        trans.exec((err, result) => {
+          if (err) {
+            reject(err);
+          } else {
+            return this._getRoutes()
+              .then((routeList) => {
+                if (routeList.length) {
+                  this.registeredRoutes = [];
+                  routeList.forEach((route) => {
+                    this.registeredRoutes.push(new Route(route));
+                  });
+                  if (this.serviceName !== 'hydra-router') {
+                    // let routers know that a new service route was registered
+                    resolve();
+                    return this._sendBroadcastMessage(UMFMessage.createMessage({
+                      to: 'hydra-router:/refresh',
+                      from: `${this.serviceName}:/`,
+                      body: {
+                        action: 'refresh',
+                        serviceName: this.serviceName
+                      }
+                    }));
+                  } else {
+                    resolve();
+                  }
                 } else {
                   resolve();
                 }
-              } else {
-                resolve();
-              }
-            })
-            .catch((err) => {
-              reject(err);
-            });
-        }
-      });
+              })
+              .catch(reject);
+          }
+        });
+      }).catch(reject);
     });
   }
 
@@ -527,7 +528,7 @@ class Hydra extends EventEmitter {
   _flushRoutes() {
     return new Promise((resolve, reject) => {
       let routesKey = `${redisPreKey}:${this.serviceName}:service:routes`;
-      this.redisdb.delete(routesKey, (err, result) => {
+      this.redisdb.del(routesKey, (err, result) => {
         if (err) {
           reject(err);
         } else {
@@ -632,7 +633,7 @@ class Hydra extends EventEmitter {
     let map = {};
     let memory = util.inspect(process.memoryUsage());
 
-    memory = memory.replace(/[\ \{\}.|\n]/g, '');
+    memory = memory.replace(/[\ \{\}]/g, '');
     lines = memory.split(',');
 
     Array.from(lines, (line) => {
@@ -848,7 +849,9 @@ class Hydra extends EventEmitter {
             reject(new Error(`Service instance for ${name} is unavailable`));
           } else {
             if (result.length > 1) {
-              result.sort((a,b) => { return (a.updatedOnTS < b.updatedOnTS) ? 1 : ((b.updatedOnTS < a.updatedOnTS) ? -1 : 0); });
+              result.sort((a, b) => {
+                return (a.updatedOnTS < b.updatedOnTS) ? 1 : ((b.updatedOnTS < a.updatedOnTS) ? -1 : 0);
+              });
             }
             resolve(result);
           }
@@ -1179,18 +1182,12 @@ class Hydra extends EventEmitter {
    * @param {object} message - UMF formatted message object
    */
   _sendMessageThroughChannel(channel, message) {
-    let messageChannel;
-    let chash = Utils.stringHash(channel);
-    if (this.messageChannelPool[chash]) {
-      messageChannel = this.messageChannelPool[chash];
-    } else {
-      messageChannel = redis.createClient(this.redisConfig);
-      this.messageChannelPool[chash] = messageChannel;
-    }
+    let messageChannel = redis.createClient(this.redisConfig);
     if (messageChannel) {
       let msg = UMFMessage.createMessage(message);
       let strMessage = Utils.safeJSONStringify(msg.toShort());
       messageChannel.publish(channel, strMessage);
+      messageChannel.quit();
     }
   }
 


### PR DESCRIPTION
While parsing the memory object, the character \n remains as the start of the properties "heapTotal", "heapUsed", "external".
Please see detailed issue (node: 7.5.0):
"memory": {
        "rss": 59314176,
        "\nheapTotal": 35631104,
        "\nheapUsed": 21309544,
        "\nexternal": 699713
      }...

Now fixed:
"memory": {
        "rss": 51007488,
        "heapTotal": 21999616,
        "heapUsed": 18682792,
        "external": 74640
      }...