### PR TITLE
provide default for this.opts in plugins

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -31,7 +31,7 @@ class HydraPlugin {
   */
   setConfig(hydraConfig) {
     this.hydraConfig = hydraConfig;
-    this.opts = hydraConfig.plugins[this.name];
+    this.opts = (hydraConfig.plugins && hydraConfig.plugins[this.name]) || {};
   }
 
   /**
@@ -43,7 +43,7 @@ class HydraPlugin {
   updateConfig(serviceConfig) {
     this.serviceConfig = serviceConfig;
     this.hydraConfig = serviceConfig.hydra;
-    let opts = this.hydraConfig.plugins[this.name];
+    let opts = (this.hydraConfig.plugins && this.hydraConfig.plugins[this.name]) || {};
     let isEqual = (JSON.stringify(this.opts) == JSON.stringify(opts));
     if (!isEqual) {
       this.configChanged(opts);


### PR DESCRIPTION
From what I can tell plugins do not necessarily need options to be passed in. Currently if no `hydra.plugins[plugin-name]` is provided in the configuration then the plugin initialization throws the error `Unhandled rejection TypeError: Cannot read property [plugin-name] of undefined`

This PR safely accesses `hydra.plugins[plugin-name]` and if it doesn't exist then defaults to an empty object.

My preference would be to use [pathOr](http://ramdajs.com/docs/#pathOr) from Ramda.js or [get](https://lodash.com/docs/4.17.4#get) from lodash, but didn't want to add new dependencies without permission.