### PR TITLE
Fixing \n char issue on memory object (node7.x)

### DIFF
--- a/index.js
+++ b/index.js
@@ -622,7 +622,7 @@ class Hydra extends EventEmitter {
     let map = {};
     let memory = util.inspect(process.memoryUsage());
 
-    memory = memory.replace(/[\ \{\}]/g, '');
+    memory = memory.replace(/[\ \{\}.|\n]/g, '');
     lines = memory.split(',');
 
     Array.from(lines, (line) => {


### PR DESCRIPTION
While parsing the memory object, the character \n remains as the start of the properties "heapTotal", "heapUsed", "external".
Please see detailed issue (node: 7.x):
"memory": {
        "rss": 59314176,
        "\nheapTotal": 35631104,
        "\nheapUsed": 21309544,
        "\nexternal": 699713
      }...

Now fixed:
"memory": {
        "rss": 51007488,
        "heapTotal": 21999616,
        "heapUsed": 18682792,
        "external": 74640
      }...