### PR TITLE
[WIP] replace "request" package

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const humanize = require('humanize-duration');
 const spawn = require('child_process').spawn;
 const Route = require('route-parser');
 
-const request = require('request');
+const popsicle = require('popsicle');
 const Utils = require('fwsp-jsutils');
 const ServerResponse = require('fwsp-server-response');
 let serverResponse = new ServerResponse();
@@ -32,6 +32,12 @@ const PRESENCE_UPDATE_INTERVAL = 500; // unit = milli-seconds, so every half sec
 const HEALTH_UPDATE_INTERVAL = 500;
 const KEY_EXPIRATION_TTL = parseInt((PRESENCE_UPDATE_INTERVAL / 1000) * 2);
 const UMF_INVALID_MESSAGE = 'UMF message requires "to", "from" and "body" fields';
+
+const request = (options, cb) => {
+  popsicle.request(options)
+    .then((res) => cb(null, res, res.body))
+    .catch((err) => cb(err, {statusCode: 500}));
+};
 
 /**
  * @name Hydra

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "fwsp-umf-message": "0.4.3",
     "humanize-duration": "3.10.0",
     "ip": "1.1.5",
+    "popsicle": "^9.1.0",
     "redis": "2.7.1",
     "redis-url": "1.2.1",
-    "request": "2.81.0",
     "route-parser": "0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently the `request` package is used in two fairly simple places. (`_tryAPIRequest` and `_makeAPIRequest`)

My initial testing has this PR working for me, though I am not at all sure that it will work in all circumstances. This PR serves to raise the question about rewriting how http requests are performed in hydra.

metrics taken with [cost-of-modules](https://github.com/siddharthkp/cost-of-modules)
## Before
<img width="343" alt="before" src="https://cloud.githubusercontent.com/assets/5205440/25206466/f6b5e840-251c-11e7-870e-85abac697288.png">

## After
<img width="341" alt="after" src="https://cloud.githubusercontent.com/assets/5205440/25206470/ff151a06-251c-11e7-8dc6-5aea2726afae.png">
 
Creating a fake `request` function is not what I would want to push to production, but it seemed to me like rewriting `_makeAPIRequest` and `_tryAPIRequest` is above my pay grade at this point. I believe that using the native `http` library or something like `node-fetch` would be a better solution long term