### PR TITLE
Set initialized = false on shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,6 +223,7 @@ class Hydra extends EventEmitter {
         this.redisdb.quit();
       });
     }
+    this.initialized = false;
   }
 
   /**


### PR DESCRIPTION
Properly set initialized flag to false after shutdown.