### PR TITLE
hydra.shutdown() returns promise

### DIFF
--- a/specs/test.js
+++ b/specs/test.js
@@ -49,12 +49,11 @@ describe('Hydra', function() {
   });
 
   afterEach((done) => {
-    hydra.shutdown();
-    setTimeout(() => {
+    hydra.shutdown().then(() => {
       let name = require.resolve('../index.js');
       delete require.cache[name];
       done();
-    }, 2000);
+    });
   });
 
   /**


### PR DESCRIPTION
This allows tests to know when shutdown has completed as opposed to waiting for two seconds before proceeding to the next test which dramatically decreases the time it takes for tests to run.