### PR TITLE
broadcast 'reconfigure' event when putConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -1412,6 +1412,23 @@ class Hydra extends EventEmitter {
     });
   }
 
+  _reconfigure(label, config) {
+    let parts = label.split(':');
+    if (parts.length !== 2) {
+      reject(new Error('label not in this form: myservice:0.1.1.'));
+    }
+
+    return this._sendBroadcastMessage(UMFMessage.createMessage({
+      to: `${parts[0]}:/`,
+      from: `${this.serviceName}:/`,
+      typ: 'reconfigure',
+      body: {
+        action: 'reconfigure',
+        label: label
+      }
+    }));
+  }
+
   /**
    * @name _putConfig
    * @summary store a configuration file
@@ -1431,6 +1448,7 @@ class Hydra extends EventEmitter {
         if (err) {
           reject(new Error('Unable to set :configs key in Redis db.'));
         } else {
+          this._reconfigure(label, config);
           resolve();
         }
       });

--- a/index.js
+++ b/index.js
@@ -1412,11 +1412,16 @@ class Hydra extends EventEmitter {
     });
   }
 
-  _reconfigure(label, config) {
+  /**
+   * @name _reconfigure
+   * @summary Sends a message to all present instances of a hydra service about the config changes
+   * @param {any} label in the format of 'my_service:1.0.0'
+   * @return {promise} Promise from sendBroadcastMessage
+   * 
+   * @memberof Hydra
+   */
+  _reconfigure(label) {
     let parts = label.split(':');
-    if (parts.length !== 2) {
-      reject(new Error('label not in this form: myservice:0.1.1.'));
-    }
 
     return this._sendBroadcastMessage(UMFMessage.createMessage({
       to: `${parts[0]}:/`,
@@ -1448,7 +1453,7 @@ class Hydra extends EventEmitter {
         if (err) {
           reject(new Error('Unable to set :configs key in Redis db.'));
         } else {
-          this._reconfigure(label, config);
+          this._reconfigure(label);
           resolve();
         }
       });

--- a/index.js
+++ b/index.js
@@ -1417,7 +1417,6 @@ class Hydra extends EventEmitter {
    * @summary Sends a message to all present instances of a hydra service about the config changes
    * @param {any} label in the format of 'my_service:1.0.0'
    * @return {promise} Promise from sendBroadcastMessage
-   * 
    * @memberof Hydra
    */
   _reconfigure(label) {

--- a/index.js
+++ b/index.js
@@ -1424,9 +1424,9 @@ class Hydra extends EventEmitter {
 
     return this._sendBroadcastMessage(UMFMessage.createMessage({
       to: `${parts[0]}:/`,
-      from: `${this.serviceName}:/`,
+      frm: `${this.serviceName}:/`,
       typ: 'reconfigure',
-      body: {
+      bdy: {
         action: 'reconfigure',
         label: label
       }


### PR DESCRIPTION
Broadcast the UMF message to service which match the first part of config label. This allow matching service to have a chance to capture the config change and do reconfigure itself.