### PR TITLE
request timeout support for umf messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1093,6 +1093,9 @@ class Hydra extends EventEmitter {
             if (umfmsg.authorization) {
               options.headers.Authorization = umfmsg.authorization;
             }
+            if (umfmsg.timeout) {
+              options.timeout = umfmsg.timeout;
+            }
             options.body = Utils.safeJSONStringify(umfmsg.body);
             serverRequest.send(Object.assign(options, sendOpts))
               .then((res) => {

--- a/lib/umfmessage.js
+++ b/lib/umfmessage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const uuid = require('uuid');
-const UMF_VERSION = 'UMF/1.4.4';
+const UMF_VERSION = 'UMF/1.4.5';
 
 /**
 * @name UMFMessage
@@ -76,6 +76,9 @@ class UMFMessage {
     if (this.message['rmid']) {
       message['rmid'] = this.message['rmid'];
     }
+    if (this.message['timeout']) {
+      message['tmo'] = this.message['timeout'];
+    }
     if (this.message['timestamp']) {
       message['ts'] = this.message['timestamp'];
     }
@@ -143,6 +146,9 @@ function createMessageInstance(message) {
   proxy.mid = message.mid || proxy.createMessageID();
   if (message.rmid) {
     proxy.rmid = message.rmid;
+  }
+  if (message.timeout || message.tmo) {
+    proxy.timeout = message.timeout || message.tmo;
   }
   proxy.timestamp = message.timestamp || message.ts || proxy.getTimeStamp();
   if (message.type || message.typ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": [


### PR DESCRIPTION
Note:  optional `sendOpts` to `hydra.makeAPIRequest` intentionally override UMF message timeouts.