### PR TITLE
Improve hydra initialization process

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ class Hydra extends EventEmitter {
    */
   init(config, testMode) {
     this.testMode = testMode;
+
     if (typeof config === 'string') {
       const configHelper = require('./lib/config');
       return configHelper.init(config)
@@ -100,23 +101,8 @@ class Hydra extends EventEmitter {
           return this.init(configHelper.getObject(), testMode);
         });
     }
+
     const initPromise = new Promise((resolve, reject) => {
-      if (!config || !config.hydra) {
-        reject(new Error('Config missing hydra branch'));
-        return;
-      }
-      if (!config.hydra.redis) {
-        reject(new Error('Config missing hydra.redis branch'));
-        return;
-      }
-      if (!config.hydra.serviceName || (!config.hydra.servicePort && !config.hydra.servicePort === 0)) {
-        reject(new Error('Config missing serviceName or servicePort'));
-        return;
-      }
-      if (config.hydra.serviceName.includes(':')) {
-        reject(new Error('Config can not have a colon character in its name'));
-        return;
-      }
       let loader = (newConfig) => {
         return Promise.series(this.registeredPlugins, (plugin) => plugin.setConfig(newConfig.hydra))
           .then((..._results) => {
@@ -132,7 +118,64 @@ class Hydra extends EventEmitter {
           });
       };
 
-      if (process.env.HYDRA_REDIS_URL && process.env.HYDRA_SERVICE) {
+      if (!config || !config.hydra) {
+        config = Object.assign({
+          'hydra': {
+            'serviceIP': '',
+            'servicePort': 0,
+            'serviceType': '',
+            'serviceDescription': '',
+            'redis': {
+              'url': 'redis://127.0.0.1:6379/15'
+            }
+          }
+        });
+      }
+
+      if (!config.hydra.redis) {
+        config.hydra = Object.assign(config.hydra, {
+          'redis': {
+            'url': 'redis://127.0.0.1:6379/15'
+          }
+        });
+      }
+
+      if (process.env.HYDRA_REDIS_URL) {
+        Object.assign(config.hydra, {
+          redis: {
+            url: process.env.HYDRA_REDIS_URL
+          }
+        });
+      }
+
+      let partialConfig = true;
+      if (process.env.HYDRA_SERVICE) {
+        let hydraService = process.env.HYDRA_SERVICE;
+        if (hydraService.includes('|')) {
+          hydraService = hydraService.replace(/(\r\n|\r|\n)/g, '');
+          let newHydraBranch = {};
+          let key = '';
+          let val = '';
+          let segs = hydraService.split('|');
+          segs.forEach((segment) => {
+            segment = segment.trim();
+            [key, val] = segment.split('=');
+            newHydraBranch[key] = val;
+          });
+          Object.assign(config.hydra, newHydraBranch);
+          if (!config.hydra.serviceName || (!config.hydra.servicePort && !config.hydra.servicePort === 0)) {
+            reject(new Error('Config missing serviceName or servicePort'));
+            return;
+          }
+          if (config.hydra.serviceName.includes(':')) {
+            reject(new Error('Config can not have a colon character in its name'));
+            return;
+          }
+          partialConfig = false;
+        }
+      }
+
+      if (partialConfig) {
         this._connectToRedis({redis: {url: process.env.HYDRA_REDIS_URL}})
           .then(() => {
             if (!this.redisdb) {

--- a/index.js
+++ b/index.js
@@ -150,8 +150,12 @@ class Hydra extends EventEmitter {
 
       let partialConfig = true;
       if (process.env.HYDRA_SERVICE) {
-        let hydraService = process.env.HYDRA_SERVICE;
-        if (hydraService.includes('|')) {
+        let hydraService = process.env.HYDRA_SERVICE.trim();
+        if (hydraService[0] === '{') {
+          let newHydraBranch = Utils.safeJSONParse(hydraService);
+          Object.assign(config.hydra, newHydraBranch);
+          partialConfig = false;
+        } if (hydraService.includes('|')) {
           hydraService = hydraService.replace(/(\r\n|\r|\n)/g, '');
           let newHydraBranch = {};
           let key = '';
@@ -172,7 +176,11 @@ class Hydra extends EventEmitter {
         return;
       }
       if (config.hydra.serviceName.includes(':')) {
-        reject(new Error('Config can not have a colon character in its name'));
+        reject(new Error('serviceName can not have a colon character in its name'));
+        return;
+      }
+      if (config.hydra.serviceName.includes(' ')) {
+        reject(new Error('serviceName can not have a space character in its name'));
         return;
       }
 

--- a/index.js
+++ b/index.js
@@ -163,19 +163,20 @@ class Hydra extends EventEmitter {
             newHydraBranch[key] = val;
           });
           Object.assign(config.hydra, newHydraBranch);
-          if (!config.hydra.serviceName || (!config.hydra.servicePort && !config.hydra.servicePort === 0)) {
-            reject(new Error('Config missing serviceName or servicePort'));
-            return;
-          }
-          if (config.hydra.serviceName.includes(':')) {
-            reject(new Error('Config can not have a colon character in its name'));
-            return;
-          }
           partialConfig = false;
         }
       }
 
-      if (partialConfig) {
+      if (!config.hydra.serviceName || (!config.hydra.servicePort && !config.hydra.servicePort === 0)) {
+        reject(new Error('Config missing serviceName or servicePort'));
+        return;
+      }
+      if (config.hydra.serviceName.includes(':')) {
+        reject(new Error('Config can not have a colon character in its name'));
+        return;
+      }
+
+      if (partialConfig && process.env.HYDRA_REDIS_URL) {
         this._connectToRedis({redis: {url: process.env.HYDRA_REDIS_URL}})
           .then(() => {
             if (!this.redisdb) {

--- a/lib/server-request.js
+++ b/lib/server-request.js
@@ -23,6 +23,7 @@ class ServerRequest {
   send(options) {
     return new Promise((resolve, reject) => {
       if (options.method === 'POST' || options.method === 'PUT') {
+        options.headers = options.headers || {};
         options.headers['content-length'] = Buffer.byteLength(options.body, 'utf8');
       } else {
         delete options.body;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.3.13",
+  "version": "1.4.6",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": [

--- a/specs/test.js
+++ b/specs/test.js
@@ -81,25 +81,42 @@ describe('Hydra', function() {
       })
       .catch((err) => {
         expect(err).to.not.be.null;
-        expect(err.message).to.equal('Config missing hydra branch');
+        expect(err.message).to.equal('Config missing serviceName or servicePort');
         done();
       });
   });
 
   /**
-  * @description Hydra should fail to load without a hydra.redis branch in configuration
+  * @description Hydra should load if serviceName and servicePort is provided
   */
-  it('should fail without config hydra.redis branch', (done) => {
+  it('should load if serviceName and servicePort is provided', (done) => {
+    hydra.init({
+      hydra: {
+        serviceName: 'test-service',
+        servicePort: 3000
+      }
+    }, true)
+      .then(() => {
+        done();
+      })
+      .catch((err) => {
+        expect(err).to.be.null;
+        done();
+      });
+  });
+
+  /**
+  * @description Hydra should load without a hydra.redis branch in configuration
+  */
+  it('should load without config hydra.redis branch', (done) => {
     let config = getConfig();
     delete config.hydra.redis;
     hydra.init(config, true)
       .then(() => {
-        expect(true).to.be.false;
         done();
       })
       .catch((err) => {
-        expect(err).to.not.be.null;
-        expect(err.message).to.equal('Config missing hydra.redis branch');
+        expect(err).to.be.null;
         done();
       });
   });


### PR DESCRIPTION
This PR seeks to improve the initialization process by offering an additional way of initializing hydra beyond the use of a configuration file and object.

The init function currently accepts a config parameter which can be an object or string. If it's a string then the string is expected to point to a file path for a configuration file. If the config parameter is an object then hydra will attempt to use the object members for initialization.

This PR adds the possibility of passing a config parameter of null or undefined.  Doing so will initiate the following flow:

* If the config is null then a new config is created with default values.
* Redis will then be expected to exists locally unless specified.
* A check is made for process.env.HYDRA_REDIS_URL. If defined then the config redis.url will point to the string specified.
* Next, process.env.HYDRA_SERVICE is checked. If that environment variable exists then it can potentially hold one of two types of formatted strings.

```
"hello-service:1.2.3"
```

or: 

```
"serviceName=hello-service|serviceDescription=A service that says hello|serviceIP=127.0.0.1|servicePort=5000|serviceType=greeter"
```

The first format is what we already use when working with Docker containers.  The second format represents a string containing pipe delimited `|` key/value pairs. The key/value pairs are separated by the `=` symbol.

The string is parsed and an internal config object is created.  

This allows a service to be started at the command line using: 

```shell
$ HYDRA_SERVICE="serviceName=hello-service|serviceDescription=A service that says hello|serviceIP=127.0.0.1|servicePort=5000|serviceType=greeter|serviceVersion=0.1.3" HYDRA_REDIS_URL=redis://localhost:6379/15" node test.js
```

This allow allows for starting a Docker container and passing the environment variables:

```shell
$ sudo docker service create \
 --name hydra-router \
 --network servicenet \
 --restart-condition any \
 --restart-max-attempts 5 \
 --update-delay 10s \
 --constraint=node.role==manager \
 --env HYDRA_REDIS_URL="redis://10.0.0.154:6379/15" \
 --env HYDRA_SERVICE="serviceName=hydra-router|serviceDescription=A service-aware router|serviceIP=|servicePort=80|serviceType=router|serviceVersion1.3.11" HYDRA_REDIS_URL="redis://localhost:6379/15"" \
 --publish 80:80 \
 --replicas=3 \
 flywheelsports/hydra-router:1.3.11
```

A side effect of this PR is that creating test services locally does not require a config file. Only `serviceName` and `servicePort` need to be defined.

