### PR TITLE
Correct request body length

### DIFF
--- a/lib/server-request.js
+++ b/lib/server-request.js
@@ -23,7 +23,7 @@ class ServerRequest {
   send(options) {
     return new Promise((resolve, reject) => {
       if (options.method === 'POST' || options.method === 'PUT') {
-        options.headers['content-length'] = options.body.length;
+        options.headers['content-length'] = Buffer.byteLength(options.body, 'utf8');
       } else {
         delete options.body;
       }


### PR DESCRIPTION
Hey @cjus, couple days ago I asked you to upgrade the Express version for hydra-express due to an error when posting to services data with special and/or non-latin chars. Apparently it wasn't the express but rather the request object. Specifically body length. Getting length of the buffer fixes that...