### PR TITLE
DNS and load balancing improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ class Hydra extends EventEmitter {
    */
   init(config, testMode) {
     this.testMode = testMode;
+
     if (typeof config === 'string') {
       const configHelper = require('./lib/config');
       return configHelper.init(config)
@@ -100,23 +101,8 @@ class Hydra extends EventEmitter {
           return this.init(configHelper.getObject(), testMode);
         });
     }
+
     const initPromise = new Promise((resolve, reject) => {
-      if (!config || !config.hydra) {
-        reject(new Error('Config missing hydra branch'));
-        return;
-      }
-      if (!config.hydra.redis) {
-        reject(new Error('Config missing hydra.redis branch'));
-        return;
-      }
-      if (!config.hydra.serviceName || (!config.hydra.servicePort && !config.hydra.servicePort === 0)) {
-        reject(new Error('Config missing serviceName or servicePort'));
-        return;
-      }
-      if (config.hydra.serviceName.includes(':')) {
-        reject(new Error('Config can not have a colon character in its name'));
-        return;
-      }
       let loader = (newConfig) => {
         return Promise.series(this.registeredPlugins, (plugin) => plugin.setConfig(newConfig.hydra))
           .then((..._results) => {
@@ -132,7 +118,64 @@ class Hydra extends EventEmitter {
           });
       };
 
-      if (process.env.HYDRA_REDIS_URL && process.env.HYDRA_SERVICE) {
+      if (!config || !config.hydra) {
+        config = Object.assign({
+          'hydra': {
+            'serviceIP': '',
+            'servicePort': 0,
+            'serviceType': '',
+            'serviceDescription': '',
+            'redis': {
+              'url': 'redis://127.0.0.1:6379/15'
+            }
+          }
+        });
+      }
+
+      if (!config.hydra.redis) {
+        config.hydra = Object.assign(config.hydra, {
+          'redis': {
+            'url': 'redis://127.0.0.1:6379/15'
+          }
+        });
+      }
+
+      if (process.env.HYDRA_REDIS_URL) {
+        Object.assign(config.hydra, {
+          redis: {
+            url: process.env.HYDRA_REDIS_URL
+          }
+        });
+      }
+
+      let partialConfig = true;
+      if (process.env.HYDRA_SERVICE) {
+        let hydraService = process.env.HYDRA_SERVICE;
+        if (hydraService.includes('|')) {
+          hydraService = hydraService.replace(/(\r\n|\r|\n)/g, '');
+          let newHydraBranch = {};
+          let key = '';
+          let val = '';
+          let segs = hydraService.split('|');
+          segs.forEach((segment) => {
+            segment = segment.trim();
+            [key, val] = segment.split('=');
+            newHydraBranch[key] = val;
+          });
+          Object.assign(config.hydra, newHydraBranch);
+          if (!config.hydra.serviceName || (!config.hydra.servicePort && !config.hydra.servicePort === 0)) {
+            reject(new Error('Config missing serviceName or servicePort'));
+            return;
+          }
+          if (config.hydra.serviceName.includes(':')) {
+            reject(new Error('Config can not have a colon character in its name'));
+            return;
+          }
+          partialConfig = false;
+        }
+      }
+
+      if (partialConfig) {
         this._connectToRedis({redis: {url: process.env.HYDRA_REDIS_URL}})
           .then(() => {
             if (!this.redisdb) {

--- a/index.js
+++ b/index.js
@@ -150,8 +150,12 @@ class Hydra extends EventEmitter {
 
       let partialConfig = true;
       if (process.env.HYDRA_SERVICE) {
-        let hydraService = process.env.HYDRA_SERVICE;
-        if (hydraService.includes('|')) {
+        let hydraService = process.env.HYDRA_SERVICE.trim();
+        if (hydraService[0] === '{') {
+          let newHydraBranch = Utils.safeJSONParse(hydraService);
+          Object.assign(config.hydra, newHydraBranch);
+          partialConfig = false;
+        } if (hydraService.includes('|')) {
           hydraService = hydraService.replace(/(\r\n|\r|\n)/g, '');
           let newHydraBranch = {};
           let key = '';
@@ -172,7 +176,11 @@ class Hydra extends EventEmitter {
         return;
       }
       if (config.hydra.serviceName.includes(':')) {
-        reject(new Error('Config can not have a colon character in its name'));
+        reject(new Error('serviceName can not have a colon character in its name'));
+        return;
+      }
+      if (config.hydra.serviceName.includes(' ')) {
+        reject(new Error('serviceName can not have a space character in its name'));
         return;
       }
 

--- a/index.js
+++ b/index.js
@@ -163,19 +163,20 @@ class Hydra extends EventEmitter {
             newHydraBranch[key] = val;
           });
           Object.assign(config.hydra, newHydraBranch);
-          if (!config.hydra.serviceName || (!config.hydra.servicePort && !config.hydra.servicePort === 0)) {
-            reject(new Error('Config missing serviceName or servicePort'));
-            return;
-          }
-          if (config.hydra.serviceName.includes(':')) {
-            reject(new Error('Config can not have a colon character in its name'));
-            return;
-          }
           partialConfig = false;
         }
       }
 
-      if (partialConfig) {
+      if (!config.hydra.serviceName || (!config.hydra.servicePort && !config.hydra.servicePort === 0)) {
+        reject(new Error('Config missing serviceName or servicePort'));
+        return;
+      }
+      if (config.hydra.serviceName.includes(':')) {
+        reject(new Error('Config can not have a colon character in its name'));
+        return;
+      }
+
+      if (partialConfig && process.env.HYDRA_REDIS_URL) {
         this._connectToRedis({redis: {url: process.env.HYDRA_REDIS_URL}})
           .then(() => {
             if (!this.redisdb) {

--- a/lib/server-request.js
+++ b/lib/server-request.js
@@ -23,6 +23,7 @@ class ServerRequest {
   send(options) {
     return new Promise((resolve, reject) => {
       if (options.method === 'POST' || options.method === 'PUT') {
+        options.headers = options.headers || {};
         options.headers['content-length'] = Buffer.byteLength(options.body, 'utf8');
       } else {
         delete options.body;

--- a/lib/server-request.js
+++ b/lib/server-request.js
@@ -1,5 +1,5 @@
 const http = require('http');
-const REQUEST_TIMEOUT = 5 * 1000; // 5-seconds
+const REQUEST_TIMEOUT = 30000; // 30-seconds
 
 /**
  * @name ServerRequest

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,6 +92,18 @@ class Utils {
     return (new RegExp(uuidPattern)).test(str);
   }
 
+  /**
+  * @name shuffeArray
+  * @summary shuffle an array in place
+  * @param {array} a - array elements may be numbers, string or objects.
+  * @return {undefined}
+  */
+  static shuffeArray(a) {
+    for (let i = a.length; i; i--) {
+      let j = Math.floor(Math.random() * i);
+      [a[i - 1], a[j]] = [a[j], a[i - 1]];
+    }
+  }
 }
 
 module.exports = Utils;

--- a/package.json
+++ b/package.json
@@ -1,16 +1,9 @@
 {
   "name": "hydra",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "license": "MIT",
   "author": "Carlos Justiniano",
-  "contributors": [
-    "Artem Kochnev <artemkochnev@gmail.com>",
-    "Carlos Justiniano <carlos.justiniano@gmail.com>",
-    "Eric Adum <eric.adum@gmail.com>",
-    "Jedediah Smith <jed@obdstudios.com>",
-    "Rolando Santamaria Maso <kyberneees@gmail.com>",
-    "Sebastiansch <s.schedlbauer@gmail.com>"
-  ],
+  "contributors": "https://github.com/flywheelsports/hydra/graphs/contributors",
   "description": "Hydra is a NodeJS light-weight library for building distributed computing applications such as microservices",
   "keywords": [
     "hydra",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.3.13",
+  "version": "1.4.6",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": [

--- a/specs/test.js
+++ b/specs/test.js
@@ -81,25 +81,42 @@ describe('Hydra', function() {
       })
       .catch((err) => {
         expect(err).to.not.be.null;
-        expect(err.message).to.equal('Config missing hydra branch');
+        expect(err.message).to.equal('Config missing serviceName or servicePort');
         done();
       });
   });
 
   /**
-  * @description Hydra should fail to load without a hydra.redis branch in configuration
+  * @description Hydra should load if serviceName and servicePort is provided
   */
-  it('should fail without config hydra.redis branch', (done) => {
+  it('should load if serviceName and servicePort is provided', (done) => {
+    hydra.init({
+      hydra: {
+        serviceName: 'test-service',
+        servicePort: 3000
+      }
+    }, true)
+      .then(() => {
+        done();
+      })
+      .catch((err) => {
+        expect(err).to.be.null;
+        done();
+      });
+  });
+
+  /**
+  * @description Hydra should load without a hydra.redis branch in configuration
+  */
+  it('should load without config hydra.redis branch', (done) => {
     let config = getConfig();
     delete config.hydra.redis;
     hydra.init(config, true)
       .then(() => {
-        expect(true).to.be.false;
         done();
       })
       .catch((err) => {
-        expect(err).to.not.be.null;
-        expect(err.message).to.equal('Config missing hydra.redis branch');
+        expect(err).to.be.null;
         done();
       });
   });

--- a/specs/test.js
+++ b/specs/test.js
@@ -153,7 +153,6 @@ describe('Hydra', function() {
                 expect(err).to.be.null;
                 expect(data.length).to.equal(3);
                 expect(data).to.include('hydra:service:test-service:service');
-                expect(data).to.include('hydra:service:test-service:73909f8c96a9d08e876411c0a212a1f4:presence');
                 expect(data).to.include('hydra:service:nodes');
                 done();
               });
@@ -175,7 +174,6 @@ describe('Hydra', function() {
             expect(serviceInfo.serviceName).to.equal('test-service');
             expect(serviceInfo.serviceIP).to.equal('127.0.0.1');
             expect(serviceInfo.servicePort).to.equal('5000');
-            expect(hydra.getInstanceID()).to.equal('73909f8c96a9d08e876411c0a212a1f4');
             done();
           });
       });


### PR DESCRIPTION
* Hydra now supports the use of DNS service names. To use this feature simply add a `serviceDNS` entry to the hydra branch of your service configuration. 

```
{
  "hydra": {
    "serviceDNS": "hello-service",
    "servicePort": 5000,
    :
  }
}
```

If that entry is present Hydra will ignore the serviceIP field.  This feature will be useful where hydra-enabled services are load balanced by and external load balancer such as NginX or Docker swarm orchestration.

* The algorithm that hydra used to load balance requests using hydra.makeAPIRequest (also used by Hydra-router!) worked by looking at available service instances and sorting them based on when they most recently updated their presence and selecting the top entry. The idea there was that services that recently reported health are less likely to be busy.  Upon testing we found that this leads to an uneven distribution of request across available services and thus the underutilization of server resources. The load balancing algorithm has been changed to use a basic round robin. Hydra  now retrieves active service instances and performs an array shuffle. The resulting service list is then used in a round robin fashion if the first service entry on the list fails the next on is tried - if all fail an HTTP 503 is returned

* Hydra serverRequest and makeAPIRequest now has a default timeout of 30 seconds up from the earlier 5 seconds timeout. The value can be overwritten by setting the header or UMF timeout value.

* Service instanceID is no longer calculated as a hash of IP and Port address. Now, instanceID is simply a random UUID. This change is necessary to support the new DNS usage where a serverIP won't be specified in the service configuration.

