### PR TITLE
allow @ characters in api routes

### DIFF
--- a/lib/umfmessage.js
+++ b/lib/umfmessage.js
@@ -188,27 +188,27 @@ function parseRoute(toValue) {
   let instance = '';
   let subID = '';
 
-  let atPos = urlRoute.indexOf('@');
-  if (atPos > -1) {
-    instance = urlRoute.substring(0, atPos);
-    urlRoute = urlRoute.substring(atPos + 1);
-    let segments = instance.split('-');
-    if (segments.length > 0) {
-      instance = segments[0];
-      subID = segments[1];
-    }
-  }
   let segments = urlRoute.split(':');
   if (segments.length < 1) {
     error = 'route field has invalid number of routable segments';
   } else {
+    let atPos = segments[0].indexOf('@');
+    if (atPos > -1) {
+      let x = segments.shift();
+      instance = x.substring(0, atPos);
+      urlRoute = x.substring(atPos + 1);
+      let segs = instance.split('-');
+      if (segs.length > 0) {
+        instance = segs[0];
+        subID = segs[1];
+      }
+    }
     if (segments[0].indexOf('http') === 0) {
       let url = `${segments[0]}:${segments[1]}`;
       segments.shift();
       segments[0] = url;
     }
-    serviceName = segments[0];
-    segments.shift();
+    serviceName = segments.shift();
     apiRoute = segments.join(':');
     let s1 = apiRoute.indexOf('[');
     if (s1 === 0) {

--- a/lib/umfmessage.js
+++ b/lib/umfmessage.js
@@ -196,7 +196,7 @@ function parseRoute(toValue) {
     if (atPos > -1) {
       let x = segments.shift();
       instance = x.substring(0, atPos);
-      urlRoute = x.substring(atPos + 1);
+      segments.unshift(x.substring(atPos + 1));
       let segs = instance.split('-');
       if (segs.length > 0) {
         instance = segs[0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": "https://github.com/flywheelsports/hydra/graphs/contributors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": [


### PR DESCRIPTION
Requests containing @ characters started failing after I updated to a recent hydra-router version. E.g. `/v1/service/setEmail/eric@flywheelsports.com`.

I haven't tested this change extensively, but it has worked with everything I did try.