### PR TITLE
Handling for unknown HTTP-Status

### DIFF
--- a/lib/server-response.js
+++ b/lib/server-response.js
@@ -42,10 +42,11 @@ class ServerResponse {
   * @return {object} response - object suitable for sending via HTTP
   */
   createResponseObject(httpCode, resultPayload) {
+    let status = ServerResponse.STATUS[httpCode] || { STATUS: [`${httpCode}`, `Unknown statusCode ${httpCode}`]}
     let response = Object.assign({
       statusCode: httpCode,
-      statusMessage: ServerResponse.STATUS[httpCode][ServerResponse.STATUSMESSAGE],
-      statusDescription: ServerResponse.STATUS[httpCode][ServerResponse.STATUSDESCRIPTION],
+      statusMessage: status[ServerResponse.STATUSMESSAGE],
+      statusDescription: status[ServerResponse.STATUSDESCRIPTION],
       result: {}
     }, resultPayload || {});
     return response;

--- a/lib/server-response.js
+++ b/lib/server-response.js
@@ -42,7 +42,7 @@ class ServerResponse {
   * @return {object} response - object suitable for sending via HTTP
   */
   createResponseObject(httpCode, resultPayload) {
-    let status = ServerResponse.STATUS[httpCode] || { STATUS: [`${httpCode}`, `Unknown statusCode ${httpCode}`]}
+    let status = ServerResponse.STATUS[httpCode] || [`${httpCode}`, `Unknown statusCode ${httpCode}`];
     let response = Object.assign({
       statusCode: httpCode,
       statusMessage: status[ServerResponse.STATUSMESSAGE],


### PR DESCRIPTION
I added a way to handle HTTP-StatusCodes for which there is no key in the ServerResponse.STATUS-object (i.e. '403').