### PR TITLE
Support for cached calls.

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+* @name Cache
+* @summary Internal cache helper
+*/
+class Cache {
+  /**
+  * @name constructor
+  * @summary constructor
+  * @return {undefined}
+  */
+  constructor() {
+    this.data = {};
+  }
+
+  /**
+  * @name put
+  * @summary put a value in the cache
+  * @param {string} key - key for value
+  * @param {any} value - value associated with key
+  * @param {number} expiration - expiration in seconds
+  * @return {undefined}
+  */
+  put(key, value, expiration = 0) {
+    this.data[key] = {
+      value,
+      ts: new Date().getTime() / 1000 | 0,
+      expiration
+    };
+  }
+
+  /**
+  * @name get
+  * @summary get a value based on key
+  * @param {string} key - key for value
+  * @return {any} value - value associated with key or undefined if missing or expired
+  */
+  get(key) {
+    let item = this.data[key];
+    if (item) {
+      let current = new Date().getTime() / 1000 | 0;
+      if (current > (item.ts + item.expiration)) {
+        this.data[key] = item = undefined;
+      }
+    }
+    return item ? item.value : undefined;
+  }
+}
+
+module.exports = new Cache;

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -48,4 +48,4 @@ class Cache {
   }
 }
 
-module.exports = new Cache;
+module.exports = Cache;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.4.29",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,9 +171,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.4.29",
+  "version": "1.5.0",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": "https://github.com/flywheelsports/hydra/graphs/contributors",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "bluebird": "3.5.0",
-    "debug": "2.6.8",
+    "debug": "2.6.9",
     "redis": "2.7.1",
     "redis-url": "1.2.1",
     "route-parser": "0.0.5",


### PR DESCRIPTION
This PR is for an important optimization in Hydra core.

The  `_checkServicePresence` method is one of the most utilized internal functions in hydra.   It's called by functions interested in knowing whether a particular service is available.  Under the hood, the function first queries Redis for keys related to a named service. The code then proceeds to query additional information for each of the returned service instances. Because this data is stored in Redis as a stringified JSON object, the returned data must be parsed to a restored JavaScript object.  Each returned object is then pushed onto an array and returned.

Although those operations are blazing fast, they're executed everytime presence information is needed. Which has the potential to be quite often!

The place those operations take their toll is when there are a lot of HTTP and socket-based messaging flowing through your microservices.  We discovered this while testing our HydraRouter microservice which handles considerably more traffic than the rest of our services.

However, this can happen in any service which calls another service hundreds of times per second. This PR is designed to cache calls to `_checkServicePresence` so that cached results are returned for all calls within three seconds.  This should greatly reduce the burden on chatty microservices and on Redis itself.

Although not strictly required I've added the same cache handling 
to the ` _getServiceHealth() ` call.

There may indeed be other places in Hydra which can benefit from internal caching. However, caching is difficult and can lead to difficult to track errors and edge cases.