### PR TITLE
Redis optimizations to reduce writes and make use of scan instead of keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.5.0",
+  "version": "1.5.2-experimental",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.5.2-experimental",
+  "version": "1.5.5",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.5.0",
+  "version": "1.5.2-experimental",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": "https://github.com/flywheelsports/hydra/graphs/contributors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.5.2-experimental",
+  "version": "1.5.5",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": "https://github.com/flywheelsports/hydra/graphs/contributors",


### PR DESCRIPTION
* Introduces use of the Redis scan command to replace the keys command #152 
* During _updatePresence two writes to Redis were eliminated.
* Use the Redis driver batch command instead of multi in strategic places.