### PR TITLE
Fixed promise chain blocking when plugin error

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ class Hydra extends EventEmitter {
         Promise.series(this.registeredPlugins, (plugin) => plugin.onServiceReady()).then((..._results) => {
           resolve();
         }).catch((err) => {
-          this._logMessage('error', err.toString())
+          this._logMessage('error', err.toString());
           reject(err);
         });
       };

--- a/index.js
+++ b/index.js
@@ -245,7 +245,10 @@ class Hydra extends EventEmitter {
       let ready = () => {
         Promise.series(this.registeredPlugins, (plugin) => plugin.onServiceReady()).then((..._results) => {
           resolve();
-        }).catch((err) => this._logMessage('error', err.toString()));
+        }).catch((err) => {
+          this._logMessage('error', err.toString())
+          reject(err);
+        });
       };
       this.config = config;
       this._connectToRedis(this.config).then(() => {


### PR DESCRIPTION
I was struggling with hydra-integration plugin and found out that the promise chain was blocked when a plugin fails to load