### PR TITLE
reset instance ID on shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -386,6 +386,7 @@ class Hydra extends EventEmitter {
         Promise.all(promises).then(resolve);
       }
       this.initialized = false;
+      this.instanceID = INSTANCE_ID_NOT_SET;
     });
   }
 


### PR DESCRIPTION
On shutdown, reset instance ID. This will allow proper: **init -> shutdown -> init -> shutdown** workflows. 
Without it, the hydra-integration tests won't pass ;(