### PR TITLE
pass options through to redis duplicate call

### DIFF
--- a/index.js
+++ b/index.js
@@ -1680,11 +1680,12 @@ class Hydra extends EventEmitter {
   /**
   * @name _getClonedRedisClient
   * @summary get a Redis client connection which points to the same Redis server that hydra is using
-  * @param {object} options - override options from original createClient call
+  * @param {object} [options] - override options from original createClient call
+  * @param {function} [callback] - callback for async connect
   * @return {object} - Redis Client
   */
-  _getClonedRedisClient(options) {
-    return this.redisdb.duplicate(options);
+  _getClonedRedisClient(options, callback) {
+    return this.redisdb.duplicate(options, callback);
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -1680,10 +1680,11 @@ class Hydra extends EventEmitter {
   /**
   * @name _getClonedRedisClient
   * @summary get a Redis client connection which points to the same Redis server that hydra is using
+  * @param {object} options - override options from original createClient call
   * @return {object} - Redis Client
   */
-  _getClonedRedisClient() {
-    return this.redisdb.duplicate();
+  _getClonedRedisClient(options) {
+    return this.redisdb.duplicate(options);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "author": "Carlos Justiniano",
   "contributors": "https://github.com/flywheelsports/hydra/graphs/contributors",


### PR DESCRIPTION
This PR passes the `options` argument through to [node_redis's `duplicate` call](https://github.com/NodeRedis/node_redis#clientduplicateoptions-callback). In this case, I need to pass `{detect_buffers: true}` on the cloned connection to make proper use of the DUMP/RESTORE Redis commands.

This is something that would not be necessary if we migrated Hydra to `ioredis`, which has a more elegant API for handling buffers.

We should probably also add the `callback` argument, to allow maximum flexibility, which if present uses a non-blocking version of the call.